### PR TITLE
add config option for non-standard admin url

### DIFF
--- a/config/blogify.php
+++ b/config/blogify.php
@@ -74,4 +74,10 @@ return [
      *
      */
     'enable_default_routes' => true,
+
+    /**
+     * Define a non-standard admin url
+     *
+     */
+    'admin_slug' => env('BLOGIFY_ADMIN_SLUG', 'admin'),
 ];

--- a/src/routes.php
+++ b/src/routes.php
@@ -52,7 +52,7 @@ Route::group(['prefix' => 'auth'], function()
 ///////////////////////////////////////////////////////////////////////////
 
 $admin = [
-    'prefix'    => 'admin',
+    'prefix'    => config('blogify.blogify.admin_slug'),
     'namespace' =>'jorenvanhocht\Blogify\Controllers\Admin',
     'middleware' => 'web',
 ];


### PR DESCRIPTION
I've been using blogify for a few days on a project i'm working on.

I've been tightening security on a few areas pre-launch and figured this change might be handy for others who want to obscure their admin url :)

cheers
