### PR TITLE
fix casing on App\User model references

### DIFF
--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -42,7 +42,7 @@ class Comment extends BaseModel
 
     public function user()
     {
-        return $this->belongsTo('App\user');
+        return $this->belongsTo('App\User');
     }
 
     public function post()

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -38,7 +38,7 @@ class Role extends BaseModel
 
     public function user()
     {
-        return $this->hasMany('App\user');
+        return $this->hasMany('App\User');
     }
 
     /*


### PR DESCRIPTION
fixed a casing error that was causing blogify to fail in production
