### PR TITLE
fix to none www

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 Blogify is a package to add a blog to your Laravel 5 application. It comes with a full admin panel with different views for all user roles.
 You can generate the public part through an artisan command but feel free to customize it, or just create your own using or models and their scopes.
 
-The documentation can be found on or website <a href="http://www.blogify.io" title="Blogify.io">www.blogify.io</a>
+The documentation can be found on or website <a href="https://blogify.io" title="Blogify.io">https://blogify.io/</a>


### PR DESCRIPTION
can't enter the website with www for this reason I fixed the issue by removing www from the link

before : 
www.blogify.io

after 
https://blogify.io/